### PR TITLE
Add info about "How to contribute" and "Code of Conduct"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@fhi.no. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# How to contribute
+
+So you're thinking about contributing to Fhi.Frontend.Style? Great! Maintaining and enhancing Fhi.Frontend.Style is a big job, so **the community's help is really appreciated.**
+
+Helping out isn't just writing code, it also includes submitting issues, helping confirm issues and improving the documentation.
+
+## Submitting Issues
+
+Requests for new features and bug reports keep the project moving forward.
+
+### Before you submit an issue
+
+- Ensure you are running the [latest version](https://github.com/folkehelseinstituttet/Fhi.Frontend.Style/releases) of Fhi.Frontend.Style
+- **Search** the [issue list](https://github.com/folkehelseinstituttet/Fhi.Frontend.Style/issues?utf8=✓&q=is%3Aissue) (including closed issues) to make sure it hasn't already been reported.
+
+### Submitting a good issue
+
+- Give the issue a short, clear title that describes the bug or feature request
+- Include steps to reproduce the issue
+- If possible, include a short code example that reproduces the issue
+- Use [markdown formatting](https://guides.github.com/features/mastering-markdown/) as appropriate to make the issue and code more readable.
+
+## Confirming Issues
+
+Before we work on issues, we must confirm them and be able to reproduce them. Confirming issues takes up a great deal of the team's time, so making that job easier is **really appreciated**.
+
+Issues that need confirmation will have the **confirm** label or be unlabeled and have **no milestone**. You can help us to confirm issues by;
+
+- Add steps to reproduce the issue
+- Test issues and provide feedback
+
+## Documentation
+
+Great documentation is essential for any open source project and Fhi.Frontend.Style is no exception. [Our README](https://github.com/folkehelseinstituttet/Fhi.Frontend.Style/blob/main/README.md) often lags behind the features that have been implemented or would benefit from better examples.
+
+**PS.** If you would like to contribute to creating an exended, and better, documentation in the form of a [Wiki](https://github.com/folkehelseinstituttet/Fhi.Frontend.Style/wiki), help is really appreciated!
+
+## Fixing Bugs and Adding Features
+
+We love pull requests, but would prefer that new contributors start with smaller issues and let us know before you contribute to prevent duplication of work.
+
+It is also a good idea to add a comment to an issue that you are working on to let everyone know. If you stop working on it, also please let us know.
+
+## License
+
+Fhi.Frontend.Style is under the [MIT license](https://github.com/folkehelseinstituttet/Fhi.Frontend.Style/blob/main/LICENSE). By contributing to Fhi.Frontend.Style, you assert that:
+
+- The contribution is your own original work.
+- You have the right to assign the copyright for the work (it is not owned by your employer, or
+  you have been given copyright assignment in writing).


### PR DESCRIPTION
"How to contribute" is a modified versjon of https://github.com/OsirisTerje/nunit3-vs-adapter/blob/master/CONTRIBUTING.md
"Code of Conduct" is stolen from https://github.com/folkehelseinstituttet/Fhi.Smittestopp.App/blob/dev/CODE_OF_CONDUCT.md as is.