### PR TITLE
Import default serif font, which is also the default font for headings

### DIFF
--- a/scss/fhi-felles/_variables.typography.scss
+++ b/scss/fhi-felles/_variables.typography.scss
@@ -40,14 +40,20 @@ $fhi-default-font-size-lg:  $fhi-font-size-2;
 $fhi-lead-font-size-xs:  $fhi-font-size-3;
 
 // Font families
-$fhi-font-family-serif-regular: 'CrimsonText', 'Cambria', serif;
+$fhi-font-family-serif: 'Crimson Text', 'Cambria', serif;
 $fhi-font-family-sans-serif-regular: 'Brandon Regular', 'Calibri', sans-serif;
 $fhi-font-family-sans-serif-medium: 'Brandon Medium', 'Calibri', sans-serif;
 $fhi-font-family-sans-serif-bold: 'Brandon Bold', 'Calibri', sans-serif;
 $fhi-font-family-sans-serif-secondary: 'Calibri', 'Trebuchet MS', sans-serif;
 $font-family-monospace: Consolas, "Liberation Mono", "Courier New", monospace;
 
+// Font-tykkelser
+$fhi-font-family-serif-weight-regular: 400;
+$fhi-font-family-serif-weight-bold: 600;
+$fhi-font-family-serif-weight-bold: 700;
+
 // Div Bootstrap resets
 $line-height-base: 1.5;
-$headings-font-family: $fhi-font-family-serif-regular;
+$headings-font-family: $fhi-font-family-serif;
+$headings-font-weight: $fhi-font-family-serif-weight-bold;
 $input-btn-font-family: $fhi-font-family-sans-serif-secondary;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,5 +1,7 @@
 // Fonter
-// No fonts are distributed with this package, but for best experiance please supply your own fonts
+@import url('https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600&display=swap');
+// Brandon Regular, Brandon Medium and Brandon Bold are not distributed with this package.
+// Please Supply your own fonts for the best experience
 
 // Variabler
 @import "./fhi-felles/variables.bootstrap-color-reset";


### PR DESCRIPTION
Adding the Crimson Text font from Google Fonts.
These fonts are licensed under the Open Font License.

Using the imported font as the default serif font.
The default serif font are also used as the default font for headings.