### PR TITLE
Bugfix/move bootstrap variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 1.4.0
+# Unreleased
+
+> Apr 6, 2021
+
+* :bug: **Bugfix** Move `bootstrap/variables` from `style.scss` to `variables.scss` so libraries can access them
+
+## 1.4.0
 
 > Mar 26, 2021
 

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -5,7 +5,6 @@
 @import "./variables";
 
 // Bootstrap
-@import "./style/bootstrap/variables"; // overrides
 @import "./node_modules/bootstrap/scss/bootstrap";
 
 // FHI Bootstrap Theme (aka. Bootstrap overrides)

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -5,3 +5,4 @@
 @import "./variables/5.typography";
 @import "./variables/6.buttons";
 @import "./variables/7.forms";
+@import "./style/bootstrap/variables";


### PR DESCRIPTION
Move `bootstrap/variables` from `style.scss` to `variables.scss` so libraries can access them