### PR TITLE
Feature/123 Sorting icons position on sortable table

### DIFF
--- a/src/bootstrap-customisations/_tables.scss
+++ b/src/bootstrap-customisations/_tables.scss
@@ -27,6 +27,7 @@ th[aria-sort] {
     color: $fhi-blue-grey-6;
     cursor: pointer;
     padding-right: $fhi-space-5;
+    position: relative;
     user-select: none;
     vertical-align: bottom;
 


### PR DESCRIPTION
Sorting icon didn't float with the cell when scrolling sideways in responsive table container.
Typically on smaller screens.