### PR TITLE
Bugfix/Sorting icons position on sortable table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-> Apr 05, 2022
+> Apr 28, 2022
 
+* :bug: **Bugfix** Issue with sorting icons on sorting table
 * :bug: **Bugfix** Prevent toggler icon on sortable table to fall down below text
 * :nut_and_bolt: **New** Added round button
 

--- a/src/bootstrap-customisations/_tables.scss
+++ b/src/bootstrap-customisations/_tables.scss
@@ -27,6 +27,7 @@ th[aria-sort] {
     color: $fhi-blue-grey-6;
     cursor: pointer;
     padding-right: $fhi-space-5;
+    position: relative;
     user-select: none;
     vertical-align: bottom;
 


### PR DESCRIPTION
Sorting icon didn't float with the cell when scrolling sideways in responsive table container