### PR TITLE
Add fhi-btn-link (fhi-btn-flat will be deprecated in next major release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-> Sep 20, 2023
+> Sep 25, 2023
 
+* :tada: **Enhancement** Add `fhi-btn-link` (`fhi-btn-flat` will be deprecated in next major release)
 * :tada: **Enhancement** Datepicker with error padding fix
 
 ## 5.6.0

--- a/src/fhi/blocks/buttons/_buttons.scss
+++ b/src/fhi/blocks/buttons/_buttons.scss
@@ -1,5 +1,5 @@
 @import "./fhi-btn.mixins";
-@import "./fhi-btn-flat.block";
+@import "./fhi-btn-link.block";
 @import "./fhi-btn-icon.block";
 @import "./fhi-btn-menu-item.block";
 @import "./fhi-btn-primary.block";

--- a/src/fhi/blocks/buttons/_fhi-btn-link.block.scss
+++ b/src/fhi/blocks/buttons/_fhi-btn-link.block.scss
@@ -1,4 +1,5 @@
-.fhi-btn-flat {
+.fhi-btn-flat, // TODO: Deprecate fhi-btn-flat in v6.0.0
+.fhi-btn-link {
     @include fhi-btn(transparent, transparent, $fhi-core-blue-1);
     border: 0;
     padding-right: $fhi-core-space-2;


### PR DESCRIPTION
My argument for this change is mainly that it is more logical naming since the button looks like a link, but also that Bootstrap has a `btn-link`: https://getbootstrap.com/docs/5.2/components/buttons/