### PR TITLE
Fixed windows scale and zoom level for custom radio button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 6.1.0
+# Unreleased
+
+> Mar 20, 2024
+
+* :tada: **Enhancement** Improved custom checkbox visuals on system zoom
+
+## 6.1.0
 
 > Mar 19, 2024
 

--- a/src/bootstrap-theme/forms/_form-check.scss
+++ b/src/bootstrap-theme/forms/_form-check.scss
@@ -4,6 +4,7 @@
 
 .form-check {
     font-size: $fhi-core-font-size-1;
+    position: relative;
 }
 
 .form-check-input {
@@ -14,24 +15,23 @@
         }
 
         &[type="radio"] {
-            background-color: $white;
+            background-color: $fhi-core-white;
             background-image: none;
+            outline: currentColor solid 0.5px;
 
             ~ .form-check-label {
-                position: relative;
-
                 &::after {
                     background-color: $fhi-core-charcoal-1;
-                    border: ($fhi-core-px * 7) solid $fhi-core-charcoal-1;
+                    border: ($fhi-core-px * 5) solid $fhi-core-white;
                     border-radius: 50%;
                     content: "";
                     position: absolute;
 
                     //$fhi-core-px * 27
-                    left: -#{($fhi-core-space-4 + $fhi-core-space-1 * 0.75)}; // 24 + 3 px
-                    top: $fhi-core-space-1 * 1.25;
-                    width: 0;
-                    height: 0;
+                    left: 0;
+                    top: 0;
+                    width: $fhi-core-px * 24;
+                    height: $fhi-core-px * 24;
                 }
             }
         }

--- a/src/fhi/blocks/_fhi-form-check-tile.block.scss
+++ b/src/fhi/blocks/_fhi-form-check-tile.block.scss
@@ -16,8 +16,8 @@
             &[type="radio"] {
                 ~ .fhi-form-check-tile__label {
                     &::after {
-                        left: $fhi-core-px * 16;
-                        top: $fhi-core-px * 13;
+                        left: $fhi-core-px * 12;
+                        top: $fhi-core-px * 9;
                         z-index: 1;
                     }
                 }


### PR DESCRIPTION
Position on bullet for checked radio button is now always in center even when changing scale and/or zoom level on Windows screen settings